### PR TITLE
Fix Milkdown image

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Little things made by me:
 
 <a title="Milkdown" href="https://github.com/Saul-Mirone/milkdown">
   <kbd>
-    <img src="https://github.com/Saul-Mirone/milkdown/blob/main/gh-pages/public/milkdown-rect.svg" width="100" height="100" alt="milkdown">
+    <img src="https://github.com/Saul-Mirone/milkdown/blob/main/website/public/milkdown-rect.svg" width="100" height="100" alt="milkdown">
   </kdb>
 </a>
 <a title="Homura" href="https://github.com/Saul-Mirone/homura">


### PR DESCRIPTION
See https://github.com/Saul-Mirone/milkdown/commit/c5d378289876f2f4c94202158d5bbcbe04a8069a

That said, I think it would be better to use https://milkdown.dev/milkdown-rect.svg, in case you want to move the file again (e.g. to a standalone repository) 😉